### PR TITLE
docs: create initial in-line documentation for ledger crate modules

### DIFF
--- a/ledger/src/account/entity.rs
+++ b/ledger/src/account/entity.rs
@@ -3,6 +3,7 @@ use derive_builder::Builder;
 
 use crate::primitives::*;
 
+/// Representation of a ledger account entity.
 pub struct Account<M> {
     pub id: AccountId,
     pub code: String,
@@ -16,6 +17,7 @@ pub struct Account<M> {
     pub created_at: DateTime<Utc>,
 }
 
+/// Representation of a ***new*** ledger account entity with required/optional properties and a builder.
 #[derive(Builder, Debug)]
 pub struct NewAccount {
     #[builder(setter(into))]

--- a/ledger/src/account/mod.rs
+++ b/ledger/src/account/mod.rs
@@ -1,3 +1,4 @@
+//! Repository for working with `Account` entities.
 mod entity;
 mod repo;
 

--- a/ledger/src/account/repo.rs
+++ b/ledger/src/account/repo.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 use super::entity::*;
 use crate::{error::*, primitives::*};
 
+/// Provides methods to interact with `Account` entities.
 #[derive(Debug, Clone)]
 pub struct Accounts {
     pool: Pool<Postgres>,

--- a/ledger/src/balance/entity.rs
+++ b/ledger/src/balance/entity.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::entry::StagedEntry;
 use crate::primitives::*;
 
+/// Representation of account's balance tracked in 3 distinct layers.
 #[derive(Debug, Clone)]
 pub struct AccountBalance {
     pub(super) balance_type: DebitOrCredit,
@@ -37,6 +38,8 @@ impl AccountBalance {
     }
 }
 
+/// Contains the details of the balance and methods to update from new
+/// entries.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BalanceDetails {
     pub journal_id: JournalId,

--- a/ledger/src/balance/mod.rs
+++ b/ledger/src/balance/mod.rs
@@ -1,3 +1,4 @@
+//! Repository for working with `AccountBalance` entities.
 mod entity;
 mod repo;
 

--- a/ledger/src/balance/repo.rs
+++ b/ledger/src/balance/repo.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use super::entity::*;
 use crate::{error::*, primitives::*};
 
+/// Provides methods to interact with `AccountBalance` entities.
 #[derive(Debug, Clone)]
 pub struct Balances {
     pool: PgPool,

--- a/ledger/src/entry/entity.rs
+++ b/ledger/src/entry/entity.rs
@@ -4,6 +4,7 @@ use rust_decimal::Decimal;
 
 use crate::primitives::*;
 
+/// Representation of a ledger transaction entry entity.
 pub struct Entry {
     pub id: EntryId,
     pub version: u32,

--- a/ledger/src/entry/mod.rs
+++ b/ledger/src/entry/mod.rs
@@ -1,3 +1,4 @@
+//! Repository for working with `Entry` (Debit/Credit) entities.
 mod entity;
 mod repo;
 

--- a/ledger/src/entry/repo.rs
+++ b/ledger/src/entry/repo.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, str::FromStr};
 use super::entity::*;
 use crate::{error::*, primitives::*};
 
+/// Provides methods to interact with `Entry` entities.
 #[derive(Debug, Clone)]
 pub struct Entries {
     pool: PgPool,

--- a/ledger/src/event.rs
+++ b/ledger/src/event.rs
@@ -1,3 +1,7 @@
+//! Set of structs and methods for handling ledger events.
+//!
+//! It defines the various types of ledger events and contains event subscribers
+//! for each of them.
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{postgres::PgListener, PgPool};
@@ -16,6 +20,7 @@ use crate::{
     balance::BalanceDetails, transaction::Transaction, AccountId, JournalId, SqlxLedgerError,
 };
 
+/// Contains fields to store & manage various ledger-related `SqlxLedgerEvent` event receivers.
 #[derive(Debug, Clone)]
 pub struct EventSubscriber {
     buffer: usize,
@@ -106,6 +111,7 @@ impl EventSubscriber {
     }
 }
 
+/// Representation of a ledger event.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(try_from = "EventRaw")]
 pub struct SqlxLedgerEvent {
@@ -133,6 +139,7 @@ impl SqlxLedgerEvent {
     }
 }
 
+/// Represents the different kinds of data that can be included in an `SqlxLedgerEvent` event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum SqlxLedgerEventData {
@@ -141,6 +148,7 @@ pub enum SqlxLedgerEventData {
     TransactionUpdated(Transaction),
 }
 
+/// Defines possible event types for `SqlxLedgerEvent`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SqlxLedgerEventType {
     BalanceUpdated,

--- a/ledger/src/journal/entity.rs
+++ b/ledger/src/journal/entity.rs
@@ -3,6 +3,7 @@ use derive_builder::Builder;
 
 use crate::primitives::*;
 
+/// Representation of a ledger journal entity.
 pub struct Journal {
     pub id: AccountId,
     pub name: String,
@@ -13,6 +14,8 @@ pub struct Journal {
     pub created_at: DateTime<Utc>,
 }
 
+/// Representation of a new ledger journal entity
+/// with required/optional properties and a builder.
 #[derive(Debug, Builder)]
 pub struct NewJournal {
     #[builder(setter(into))]

--- a/ledger/src/journal/mod.rs
+++ b/ledger/src/journal/mod.rs
@@ -1,3 +1,4 @@
+//! Repository for working with `Journal` entities.
 mod entity;
 mod repo;
 

--- a/ledger/src/journal/repo.rs
+++ b/ledger/src/journal/repo.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use super::entity::*;
 use crate::{error::*, primitives::*};
 
+/// Provides methods to interact with `Journal` entities.
 #[derive(Debug, Clone)]
 pub struct Journals {
     pool: Pool<Postgres>,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -1,3 +1,10 @@
+//! # sqlx-ledger
+//!
+//! This crate builds on the sqlx crate to provide a set of primitives for
+//! implementing an SQL-compatible double-entry accounting system. This system
+//! is engineered specifically for dealing with money and building financial
+//! products.
+
 #![cfg_attr(feature = "fail-on-warnings", deny(warnings))]
 #![cfg_attr(feature = "fail-on-warnings", deny(clippy::all))]
 

--- a/ledger/src/transaction/mod.rs
+++ b/ledger/src/transaction/mod.rs
@@ -1,3 +1,4 @@
+//! Repository for working with `Transaction` entities.
 mod entity;
 mod repo;
 

--- a/ledger/src/transaction/repo.rs
+++ b/ledger/src/transaction/repo.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 use super::entity::*;
 use crate::{error::*, primitives::*};
 
+/// Provides methods to interact with `Transaction` entities.
 #[derive(Debug, Clone)]
 pub struct Transactions {
     pool: Pool<Postgres>,

--- a/ledger/src/tx_template/entity.rs
+++ b/ledger/src/tx_template/entity.rs
@@ -6,6 +6,11 @@ use cel_interpreter::CelExpression;
 use super::param_definition::*;
 use crate::primitives::*;
 
+/// Representation of a new TxTemplateCore created via a builder.
+///
+/// TxTemplateCore is an entity that takes a set of params including
+/// a `TxInput` entity and a set of `EntryInput` entities. It can
+/// later be used to create a `Transaction`.
 #[derive(Builder)]
 pub struct NewTxTemplate {
     #[builder(setter(into))]
@@ -38,6 +43,7 @@ impl NewTxTemplateBuilder {
     }
 }
 
+/// Contains the transaction-level details needed to create a `Transaction`.
 #[derive(Clone, Serialize, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct TxInput {
@@ -80,6 +86,7 @@ impl TxInputBuilder {
     }
 }
 
+/// Contains the details for each accounting entry in a `Transaction`.
 #[derive(Clone, Serialize, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct EntryInput {

--- a/ledger/src/tx_template/mod.rs
+++ b/ledger/src/tx_template/mod.rs
@@ -1,3 +1,4 @@
+//! Repository for working with `TxTemplateCore` entities.
 mod core;
 mod entity;
 mod param_definition;

--- a/ledger/src/tx_template/param_definition.rs
+++ b/ledger/src/tx_template/param_definition.rs
@@ -2,6 +2,7 @@ use cel_interpreter::{CelContext, CelExpression, CelType, CelValue};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
+/// Contains the parameters used to create a new `TxTemplate`
 #[derive(Clone, Debug, Deserialize, Serialize, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
 pub struct ParamDefinition {

--- a/ledger/src/tx_template/repo.rs
+++ b/ledger/src/tx_template/repo.rs
@@ -6,6 +6,7 @@ use tracing::instrument;
 use super::{core::*, entity::*};
 use crate::{error::*, primitives::*};
 
+/// Provides methods to interact with `TxTemplateCore` entities.
 #[derive(Debug, Clone)]
 pub struct TxTemplates {
     pool: Pool<Postgres>,


### PR DESCRIPTION
## Description

This PR is a first-pass at documenting some of the structs in the `ledger` crate modules. It has been opened as a draft since while some of the abstractions were clear, I'm still wrapping my head around others (specifically the ones in the `tx_template` module and how they relate to `transaction` module).

It is expected that these docs will eventually be live at: https://docs.rs/sqlx-ledger/latest/sqlx_ledger/

### To build locally

The documentation web-view can be generated and reviewed locally using the following.

```bash
$ docker compose up
$ cargo doc
$ cargo doc --open
```