### PR TITLE
fix: audit and slugs issues

### DIFF
--- a/cel-interpreter/Cargo.toml
+++ b/cel-interpreter/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/GaloyMoney/sqlx-ledger"
 version = "0.11.4-dev"
 edition = "2021"
 license = "MIT"
-categories = ["parsing", "cel"]
+categories = ["parsing"]
 
 [features]
 

--- a/cel-parser/Cargo.toml
+++ b/cel-parser/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.11.4-dev"
 authors = ["Justin Carter <justin@galoy.io>"]
 edition = "2021"
 license = "MIT"
-categories = ["parsing", "cel"]
+categories = ["parsing"]
 
 [features]
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694422566,
-        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
         "type": "github"
       },
       "original": {
@@ -43,19 +43,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1694657451,
-        "narHash": "sha256-cRZa9ZmUi0EFKcmzpsOXLVhiMQD8XLrku8v+U1YiGm8=",
+        "lastModified": 1732588352,
+        "narHash": "sha256-J2/hxOO1VtBA/u+a+9E+3iJpWT3xsBdghgYAVfoGCJo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7c4f46f0b3597e3c4663285e6794194e55574879",
+        "rev": "414e748aae5c9e6ca63c5aafffda03e5dad57ceb",
         "type": "github"
       },
       "original": {

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 version = "0.11.4-dev"
 edition = "2021"
 license = "MIT"
-categories = ["accounting", "ledger"]
+categories = ["finance"]
 
 [features]
 
@@ -22,15 +22,22 @@ rust_decimal = "1.30"
 derive_builder = "0.20"
 serde = "1.0"
 serde_json = "1.0"
-sqlx = { version = "0.7.1", features = ["runtime-tokio-rustls", "postgres", "rust_decimal", "uuid", "chrono", "json" ] }
+sqlx = { version = "0.8.2", features = [
+    "runtime-tokio-rustls",
+    "postgres",
+    "rust_decimal",
+    "uuid",
+    "chrono",
+    "json",
+] }
 thiserror = "1.0"
 tokio = { version = "1.28", features = ["macros"] }
 uuid = { version = "1.3", features = ["serde", "v4"] }
 rusty-money = { version = "0.4", features = ["iso", "crypto"] }
 tracing = "0.1"
-opentelemetry = { version =  "0.23", optional = true }
+opentelemetry = { version = "0.23", optional = true }
 tracing-opentelemetry = { version = "0.24", optional = true }
-cached = { version = "0.49", features = ["async"] }
+cached = { version = "0.54.0", features = ["async"] }
 
 
 [dev-dependencies]

--- a/ledger/src/primitives.rs
+++ b/ledger/src/primitives.rs
@@ -148,7 +148,7 @@ where
     &'r str: sqlx::Decode<'r, DB>,
 {
     fn decode(
-        value: <DB as sqlx::database::HasValueRef<'r>>::ValueRef,
+        value: <DB as sqlx::Database>::ValueRef<'r>,
     ) -> Result<Currency, Box<dyn std::error::Error + 'static + Send + Sync>> {
         let value = <&str as sqlx::Decode<DB>>::decode(value)?;
 


### PR DESCRIPTION
- Fix audit issues with sqlx and cached crates
- Update flake deps to resolve build issue
```
Compiling idna v1.0.3
error[E0658]: use of unstable library feature 'error_in_core'
```
- Update and remove unsupported categories to avoid release issues. Check supported slugs here https://crates.io/category_slugs
```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): The following category slugs are not currently supported on crates.io: cel
```